### PR TITLE
OT116 - fix linebreak-style added

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -21,6 +21,6 @@
         "react/prop-types": 0,
         "jsx-props-no-spreading": 0,
         "func-names": 0,
-        "linebreak-style": ["error", "windows"]
+        "linebreak-style": 0
     }
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,6 +20,7 @@
     "rules": {
         "react/prop-types": 0,
         "jsx-props-no-spreading": 0,
-        "func-names": 0
+        "func-names": 0,
+        "linebreak-style": ["error", "windows"]
     }
 }

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,5 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn run test:nowatch
-yarn run lint
+yarn test:nowatch
+yarn lint


### PR DESCRIPTION
### SUMMARY

[OT116 - fix Linebreak-style](https://github.com/alkemyTech/OT116-CLIENT/tree/OT116---Fix-linebreak-style---Windows)

Descripción: 
Error al correr el proyecto con npm start.
Ejemplo del Error: Expected linebreaks to be 'LF' but found 'CRLF'  linebreak-style

![image](https://user-images.githubusercontent.com/35880813/146195475-fd31751d-a4f0-4bdf-82e2-41a40529c807.png)

Solución:
Se incorporó una línea a la configuración de eslint en el achivo .eslintrc.json (línea 24).

![image](https://user-images.githubusercontent.com/35880813/146195864-64e9b66d-05b4-4dd1-acf5-901c7864345f.png)

Y el proyecto corre normalmente en el navegador.
![image](https://user-images.githubusercontent.com/35880813/146195974-13ea89fe-918e-4fb2-a53a-eb72c06a0e75.png)
 