### PR TITLE
OT116-25 - Private Services - Reusable Get Method

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -9,7 +9,7 @@ export default function getHeaderAuthorization() {
 }
 
 export async function getPrivate(url, id) {
-  const targetURL = `${url}/${id}`;
+  const targetURL = id ? `${url}/${id}` : url;
   const request = await axios.get(targetURL, {
     headers: getHeaderAuthorization(),
   });

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-export function getHeaderAuthorization() {
+export default function getHeaderAuthorization() {
   const isTokenSaved = window.localStorage.getItem('token');
 
   return {

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -13,5 +13,5 @@ export async function getPrivate(url, id) {
   const request = await axios.get(targetURL, {
     headers: getHeaderAuthorization(),
   });
-  return request.data;
+  return request.data.data;
 }

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -9,10 +9,15 @@ export default function getHeaderAuthorization() {
   };
 }
 
+const headers = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'access-control-allow-methods': 'GET, PUT, PATCH, POST, DELETE, OPTIONS',
+  ...getHeaderAuthorization(),
+};
+
 export async function getPrivateById(url, id) {
   const targetURL = `${url}/${id}`;
-  const request = await axios.get(targetURL, {
-    headers: getHeaderAuthorization(),
-  });
+  const request = await axios.get(targetURL, headers);
   return request.data.data;
 }

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -9,7 +9,7 @@ export default function getHeaderAuthorization() {
   };
 }
 
-export async function getPrivate(url, id) {
+export async function getPrivateById(url, id) {
   const targetURL = id ? `${url}/${id}` : url;
   const request = await axios.get(targetURL, {
     headers: getHeaderAuthorization(),

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -21,3 +21,9 @@ export async function getPrivateById(url, id) {
   const request = await axios.get(targetURL, headers);
   return request.data.data;
 }
+
+export async function patchPrivateById(url, id, body) {
+  const targetURL = `${url}/${id}`;
+  const request = await axios.patch(targetURL, body, headers);
+  return request.data.data;
+}

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -1,7 +1,17 @@
-export default function getHeaderAuthorization() {
+import axios from 'axios';
+
+export function getHeaderAuthorization() {
   const isTokenSaved = window.localStorage.getItem('token');
 
   return {
     Authorization: `Bearer ${isTokenSaved}`,
   };
+}
+
+export async function getPrivate(url, id) {
+  const targetURL = `${url}/${id}`;
+  const request = await axios.get(targetURL, {
+    headers: getHeaderAuthorization(),
+  });
+  return request.data;
 }

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -10,7 +10,7 @@ export default function getHeaderAuthorization() {
 }
 
 export async function getPrivateById(url, id) {
-  const targetURL = id ? `${url}/${id}` : url;
+  const targetURL = `${url}/${id}`;
   const request = await axios.get(targetURL, {
     headers: getHeaderAuthorization(),
   });


### PR DESCRIPTION
# Summary 
El Ticket OT116-25 tenia como consigna: ***Crear un metodo que acceda a los endpoints privados y realice una peticion GET***.

## Details
- Recibe como Parametros: 
1. **url:** Un string con la url del recurso.  
2. **id:** Un entero como el id del recurso en si, puede ser null.
- Utiliza el metodo de autorización creado en el ticket OT116-26.
- Retorna una promesa con los datos de la peticion.
- Si el id es nulo, utiliza la url normal sin el parametro en cuestion.

# Evidence
### El resultado de la peticion con una url de ejemplo:

https://user-images.githubusercontent.com/73983475/147178358-6715d325-0534-438c-8625-26e1974df21d.mp4

