### PR TITLE
OT116-31: Public Api Services: GET petition

### DIFF
--- a/src/Components/Services/publicApiServices.js
+++ b/src/Components/Services/publicApiServices.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const baseUrl = 'http://ongapi.alkemy.org/api/';
+
+export const getEndpoint = async (path) => {
+  const res = await axios.get(baseUrl + path);
+  return res.data.data;
+};
+
+export const getEndpointById = async (path, id) => {
+  const res = await axios.get(`${baseUrl}${path}/${id}`);
+  return res.data.data;
+};


### PR DESCRIPTION
# OT116-31: Public API Services: GET

## Resumen:
- Se realiza el método reutilizable para hacer peticiones GET a los endpoints públicos de la API.
- Asimismo se desarrolla el método para las peticiones GET específicas por ID.