### PR TITLE
OT116-32: Public Api Services: Post

### DIFF
--- a/src/Components/Services/publicApiServices.js
+++ b/src/Components/Services/publicApiServices.js
@@ -1,0 +1,13 @@
+import axios from 'axios';
+
+const baseUrl = 'http://ongapi.alkemy.org/api/';
+
+export const getEndpoint = async (path) => {
+  const res = await axios.get(baseUrl + path);
+  return res.data.data;
+};
+
+export const getEndpointById = async (path, id) => {
+  const res = await axios.get(`${baseUrl}${path}/${id}`);
+  return res.data.data;
+};

--- a/src/Components/Services/publicApiServices.js
+++ b/src/Components/Services/publicApiServices.js
@@ -11,3 +11,7 @@ export const getEndpointById = async (path, id) => {
   const res = await axios.get(`${baseUrl}${path}/${id}`);
   return res.data.data;
 };
+
+export const postToEndpoint = async (path, data) => {
+  await axios.post((baseUrl + path), data);
+};


### PR DESCRIPTION
# OT116-32: Public Api Services: Post

## Resumen
- Realización del método POST para envío de datos a la API pública.

## Observaciones:
- Al simular el envío de datos, se recibe un código de estado 200, pero al analizar la respuesta en la solapa Red del inspector se recibe un error
![2](https://user-images.githubusercontent.com/80296219/147287853-3fdae4bb-3901-442e-beb2-b9d64241fa22.png)

![3](https://user-images.githubusercontent.com/80296219/147287872-edd57803-983d-4ec7-8635-e3b659794701.png)

