### PR TITLE
OT116-29 - Private Services - Patch By Id Method

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -9,18 +9,18 @@ export default function getHeaderAuthorization() {
   };
 }
 
-const headers = {
-  ...getHeaderAuthorization(),
-};
-
 export async function getPrivateById(url, id) {
   const targetURL = id ? `${url}/${id}` : url;
-  const request = await axios.get(targetURL, headers);
+  const request = await axios.get(targetURL, {
+    headers: getHeaderAuthorization(),
+  });
   return request.data.data;
 }
 
 export async function patchPrivateById(url, id, body) {
   const targetURL = `${url}/${id}`;
-  const request = await axios.patch(targetURL, body, headers);
+  const request = await axios.patch(targetURL, body, {
+    headers: getHeaderAuthorization(),
+  });
   return request.data.data;
 }

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -9,18 +9,21 @@ export default function getHeaderAuthorization() {
   };
 }
 
+const headers = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+  'access-control-allow-methods': 'GET, PUT, PATCH, POST, DELETE, OPTIONS',
+  ...getHeaderAuthorization(),
+};
+
 export async function getPrivateById(url, id) {
   const targetURL = `${url}/${id}`;
-  const request = await axios.get(targetURL, {
-    headers: getHeaderAuthorization(),
-  });
+  const request = await axios.get(targetURL, headers);
   return request.data.data;
 }
 
 export async function patchPrivateById(url, id, body) {
   const targetURL = `${url}/${id}`;
-  const request = await axios.patch(targetURL, body, {
-    headers: getHeaderAuthorization(),
-  });
+  const request = await axios.patch(targetURL, body, headers);
   return request.data.data;
 }

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -9,10 +9,18 @@ export default function getHeaderAuthorization() {
   };
 }
 
+const headers = {
+  ...getHeaderAuthorization(),
+};
+
 export async function getPrivateById(url, id) {
   const targetURL = id ? `${url}/${id}` : url;
-  const request = await axios.get(targetURL, {
-    headers: getHeaderAuthorization(),
-  });
+  const request = await axios.get(targetURL, headers);
+  return request.data.data;
+}
+
+export async function patchPrivateById(url, id, body) {
+  const targetURL = `${url}/${id}`;
+  const request = await axios.patch(targetURL, body, headers);
   return request.data.data;
 }


### PR DESCRIPTION
# Summary 
En este ticket se me pedia implementar el metodo patch que recibe una URL, un ID, y un BODY para realizar la peticion PATCH,
la cual agrega el BODY provisto al objeto con el ID dado en la URL. Si algunas propiedades del BODY no existen en el recurso encontrado estas se agregan.

## Observations

- Cuando la petición se realiza retorna el objeto cambiado.
- Utilice la API de jsonplaceholder para probar el metodo ya que para probarlo con la API de alkemy necesito el token de Autorización.


# Evidence 
https://user-images.githubusercontent.com/73983475/147369314-8166231b-f83f-4793-9aeb-6db3617b24ca.mp4