### PR TITLE
OT116-30 - Reusable Delete method Priv. EndPoints

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -23,3 +23,10 @@ export async function postPrivateEndPoint(path, data) {
   });
   return request.data; // return request or request.data.....
 }
+
+export async function deletePrivateEndPointById(path, id) {
+  const request = await axios.delete(`${baseUrl + path}/${id}`, {
+    headers,
+  });
+  return request.data; // return request or request.data.....
+}


### PR DESCRIPTION
[OT116-30](https://github.com/alkemyTech/OT116-CLIENT/tree/OT116-30)

### SUMMARY

Se creó un método reutilizable para efectuar una petición DELETE a los endPoints privados de la api.
Recibe un path y un Id. 
El path se une a la url base que puede importarse desde donde se almacene esta info.
También utiliza un objeto headers que puede importarse desde donde se encuentren almacenado.

**EVIDENCE** 

Se hizo una prueba en la home.
El resultado fue que la slide no se fue encontrada.
![image](https://user-images.githubusercontent.com/35880813/147417016-112982c6-a202-4990-91fe-07a9602c798c.png)

![image](https://user-images.githubusercontent.com/35880813/147417041-108b2a84-fbff-479d-b9d3-3fec3474cbfe.png)

Es el mismo resultado que se obtiene en las pruebas de la documentación de la api.
![image](https://user-images.githubusercontent.com/35880813/147417053-9939d4e5-c317-4a74-b982-46883d98bfc9.png)
