### PR TITLE
OT116-109: slides search form

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ckeditor": "4.12.1",
     "date-fns": "2.23.0",
     "formik": "2.2.6",
+    "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react": "17.0.2",
     "react-awesome-reveal": "^3.8.1",

--- a/src/Components/Search/Search.css
+++ b/src/Components/Search/Search.css
@@ -1,0 +1,31 @@
+.search {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+	width: 50vw;
+	padding: 7px;
+	font-size: 1.3rem;
+	color: rgb(99, 99, 99);
+	box-sizing: border-box;
+	outline: none;
+	border-radius: 5px;
+	font-weight: bold;
+}
+
+.autocomplete {
+	width: 50vw;
+	background: #ffff;
+	border-radius: 5px;
+	box-shadow: 0 2px 6px rgba(0,0,0,0.3);
+}
+
+.autocompleteItems {
+	border-bottom: 1px solid #e6e6e6;
+	padding: 10px 5px;
+	cursor: pointer;
+}
+
+.autocompleteItems:hover {
+	background: rgb(228, 226, 226);
+}

--- a/src/Components/Search/Search.jsx
+++ b/src/Components/Search/Search.jsx
@@ -1,0 +1,45 @@
+import React, { useState } from 'react';
+import { debounce } from 'lodash';
+import './Search.css';
+
+const Debounce = () => {
+  const [searchfilter, setSearchfilter] = useState('');
+  const [message, setMessage] = useState('');
+
+  const handleChange = debounce((value) => {
+    if (value.length >= 3) {
+      fetch(`http://ongapi.alkemy.org/api/slides?search=${value}`)
+        .then((res) => res.json())
+        .then((json) => {
+          setSearchfilter(json.data);
+          setMessage('No hay resultados para tu búsqueda');
+        });
+    } else {
+      setMessage('Ingresa al menos 3 caracteres para la búsqueda');
+    }
+  }, 500);
+
+  return (
+    <>
+      <input
+        type="text"
+        className="search"
+        placeholder="Buscar"
+        onChange={(e) => handleChange(e.target.value)}
+      />
+      {searchfilter.length > 0 ? (
+        <div className="autocomplete">
+          {searchfilter.map((el) => (
+            <div className="autocompleteItems">
+              <span>{el.name}</span>
+            </div>
+          ))}
+        </div>
+      ) : (
+        <p>{message}</p>
+      )}
+    </>
+  );
+};
+
+export default Debounce;


### PR DESCRIPTION
# OT116-109: slides search form

## Resumen:
- Esta rama fue originalmente creada por Gonzalo con la creación del formulario, sus estilos y el efecto debounce.
- Posteriormente trabaje en ella para añadir la validación de la cantidad de letras en el valor de búsqueda y en la conexión al endpoint solicitado.
- También se añadieron mensajes al usuario en caso de que las letras ingresadas sean menos que 3 y en caso de que no haya resultados para su búsqueda.
- Por error, el merge se realizó de manera equivocada, obligándome a eliminar la rama original, y crearla nuevamente.

## Evidencia:

https://user-images.githubusercontent.com/80296219/147425863-03c3d084-661b-4059-b03b-28bbbbca0911.mp4


