### PR TITLE
OT116-50: Show error message

### DIFF
--- a/src/Components/Alerts/ErrorAlert.jsx
+++ b/src/Components/Alerts/ErrorAlert.jsx
@@ -1,11 +1,11 @@
 import React, { useEffect } from 'react';
 import Debounce from '../Search/Search';
-import { getEndpoint } from '../Services/publicApiServices';
+import { getEndpointById } from '../Services/publicApiServices';
 import { alertInfo } from './alerts';
 
 const ErrorAlert = () => {
   const getDataFromApi = () => {
-    getEndpoint('slides')
+    getEndpointById('slides', 100)
       .then((data) => console.log('data', data))
       .catch((err) => alertInfo('Ha ocurrido un error', err.message, 'error'));
   };

--- a/src/Components/Alerts/ErrorAlert.jsx
+++ b/src/Components/Alerts/ErrorAlert.jsx
@@ -1,0 +1,24 @@
+import React, { useEffect } from 'react';
+import Debounce from '../Search/Search';
+import { getEndpoint } from '../Services/publicApiServices';
+import { alertInfo } from './alerts';
+
+const ErrorAlert = () => {
+  const getDataFromApi = () => {
+    getEndpoint('slides')
+      .then((data) => console.log('data', data))
+      .catch((err) => alertInfo('Ha ocurrido un error', err.message, 'error'));
+  };
+
+  useEffect(() => {
+    getDataFromApi();
+  }, []);
+
+  return (
+    <div>
+      <Debounce />
+    </div>
+  );
+};
+
+export default ErrorAlert;

--- a/src/Components/Services/publicApiServices.js
+++ b/src/Components/Services/publicApiServices.js
@@ -3,8 +3,12 @@ import axios from 'axios';
 const baseUrl = 'http://ongapi.alkemy.org/api/';
 
 export const getEndpoint = async (path) => {
-  const res = await axios.get(baseUrl + path);
-  return res.data.data;
+  try {
+    const res = await axios.get(baseUrl + path);
+    return res.data.data;
+  } catch (error) {
+    return error.data;
+  }
 };
 
 export const getEndpointById = async (path, id) => {

--- a/src/Components/Services/publicApiServices.js
+++ b/src/Components/Services/publicApiServices.js
@@ -7,11 +7,15 @@ export const getEndpoint = async (path) => {
     const res = await axios.get(baseUrl + path);
     return res.data.data;
   } catch (error) {
-    return error.data;
+    throw error.response.data;
   }
 };
 
 export const getEndpointById = async (path, id) => {
-  const res = await axios.get(`${baseUrl}${path}/${id}`);
-  return res.data.data;
+  try {
+    const res = await axios.get(`${baseUrl}${path}/${id}`);
+    return res.data.data;
+  } catch (error) {
+    throw error.response.data;
+  }
 };


### PR DESCRIPTION
# OT116-50: Show error message

## Resumen:
Utilizando la función getEndpointById() de los servicios públicos de la API, edite la misma añadiendo la respuesta a la llamada en caso de error mediante un bloque try / catch.
Luego cree un componente ErrorAlert que llama a la función, y reutiliza el componente alertInfo para mostrar el mensaje en caso de error en la respuesta de la API. Para ello usé un id no existente que devuelva un error 404 con el mensaje "Slide not found"

Esto se realizó en las llamadas públicas de la API. El componente Debounce solo se utilizó a los fines de la visualización de un componente.

### Evidencia
Nota: El alert se visualiza a partir del segundo 15.

https://user-images.githubusercontent.com/80296219/148157205-1b9dcdcb-32dd-4607-9b5a-b46351eb6f27.mp4


