### PR TITLE
OT116-28 -Reusable Put method for Private Endpoint

### DIFF
--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -42,3 +42,10 @@ export async function deletePrivateEndPointById(path, id) {
   });
   return request.data; // return request or request.data.....
 }
+
+export async function putPrivateEndPoint(path, id, data) {
+  const request = await axios.put(`${baseUrl + path}/${id}`, data, {
+    headers,
+  });
+  return request.data; // return request or request.data.....
+}


### PR DESCRIPTION
[OT116-28](https://github.com/alkemyTech/OT116-CLIENT/tree/OT116-28)

### SUMMARY

Se creó un método reutilizable para realizar peticiones PUT a los endPoints Privados de la API.
El método recibe un path, un id y un objeto data.
El path se una a la urlBase que puede ser importada desde donde se hubiese almacenado.
También recibe un objeto headers que permite configurar los encabezados y puede importarse desde donde se hubiese almacenado.

**EVIDENCE**
Se realizó una prueba desde la home.
Recibimos como respuesta que el slide al que se quiere hacer un update no existe aún en el back.
![image](https://user-images.githubusercontent.com/35880813/147418193-746e7bae-43f1-497d-9e1a-de2ec12b3c36.png)

![image](https://user-images.githubusercontent.com/35880813/147418219-b5b60eed-6f79-458a-99ee-04afa186effe.png)

Lo mismo sucede desde las pruebas de la documentación de la api

![image](https://user-images.githubusercontent.com/35880813/147418236-4e5a2363-a800-4f88-8d2a-6b5b2f242711.png)
