### PR TITLE
OT116-34 - Services - ActivitiesServices

### DIFF
--- a/src/Components/Home/index.jsx
+++ b/src/Components/Home/index.jsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import Slider from '../Slider/Slider';
 import arraySlides, { arraySlidesEscolar } from '../../constants/arraySliders';
-import configSlider, { configSliderEscolar } from '../../constants/configSliders';
+import configSlider, {
+  configSliderEscolar,
+} from '../../constants/configSliders';
 
 const Home = function () {
   return (

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -1,4 +1,8 @@
-import { getPrivateById, patchPrivateById } from './privateApiService';
+import {
+  deletePrivateEndPointById,
+  getPrivateById, patchPrivateById,
+  postPrivateEndPoint,
+} from './privateApiService';
 import { getEndpoint } from '../Components/Services/publicApiServices';
 
 const baseURL = 'http://ongapi.alkemy.org/api/activities';
@@ -19,9 +23,25 @@ export const getActivityById = async (id) => {
   }
 };
 
-export const updateActivityById = async (id, updatedActivity) => {
+export const patchActivityById = async (id, updatedActivity) => {
   try {
     return await patchPrivateById(baseURL, id, updatedActivity);
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const addActivity = async (data) => {
+  try {
+    return await postPrivateEndPoint('activities', data);
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const deleteActivity = async (id) => {
+  try {
+    return await deletePrivateEndPointById('activities', id);
   } catch (error) {
     throw new Error(error);
   }

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -2,6 +2,7 @@ import {
   deletePrivateEndPointById,
   getPrivateById, patchPrivateById,
   postPrivateEndPoint,
+  putPrivateEndPoint,
 } from './privateApiService';
 import { getEndpoint } from '../Components/Services/publicApiServices';
 
@@ -9,7 +10,7 @@ const baseURL = 'http://ongapi.alkemy.org/api/activities';
 
 export const getAllActivities = async () => {
   try {
-    return await getEndpoint('/activities');
+    return await getEndpoint('activities');
   } catch (error) {
     throw new Error(error);
   }
@@ -40,10 +41,19 @@ export const addActivity = async (data) => {
   }
 };
 
-export const deleteActivity = async (id) => {
+export const deleteActivityById = async (id) => {
   try {
     const req = await deletePrivateEndPointById('activities', id);
     return req;
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const updateActivityById = async (id, data) => {
+  try {
+    const req = await putPrivateEndPoint('activities', id, data);
+    return req.data;
   } catch (error) {
     throw new Error(error);
   }

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -13,7 +13,7 @@ export const getAllActivities = async () => {
   try {
     return await getEndpoint('activities');
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error?.message);
   }
 };
 
@@ -21,7 +21,7 @@ export const getActivityById = async (id) => {
   try {
     return await getPrivateById(baseURL, id);
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error?.message);
   }
 };
 
@@ -29,7 +29,7 @@ export const patchActivityById = async (id, data) => {
   try {
     return await patchPrivateById(baseURL, id, data);
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error?.message);
   }
 };
 
@@ -38,7 +38,7 @@ export const addActivity = async (data) => {
     const req = await postPrivateEndPoint('activities', data);
     return req.data;
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error?.message);
   }
 };
 
@@ -47,7 +47,7 @@ export const deleteActivityById = async (id) => {
     const req = await deletePrivateEndPointById('activities', id);
     return req;
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error?.message);
   }
 };
 
@@ -56,6 +56,6 @@ export const updateActivityById = async (id, data) => {
     const req = await putPrivateEndPoint('activities', id, data);
     return req.data;
   } catch (error) {
-    throw new Error(error);
+    throw new Error(error?.message);
   }
 };

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -33,7 +33,8 @@ export const patchActivityById = async (id, updatedActivity) => {
 
 export const addActivity = async (data) => {
   try {
-    return await postPrivateEndPoint('activities', data);
+    const req = await postPrivateEndPoint('activities', data);
+    return req.data;
   } catch (error) {
     throw new Error(error);
   }
@@ -41,7 +42,8 @@ export const addActivity = async (data) => {
 
 export const deleteActivity = async (id) => {
   try {
-    return await deletePrivateEndPointById('activities', id);
+    const req = await deletePrivateEndPointById('activities', id);
+    return req;
   } catch (error) {
     throw new Error(error);
   }

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -19,7 +19,7 @@ export const getActivityById = async (id) => {
   }
 };
 
-export const updateActivity = async (id) => {
+export const updateActivityById = async (id) => {
   try {
     return await patchPrivateById(baseURL, id);
   } catch (error) {

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -25,9 +25,9 @@ export const getActivityById = async (id) => {
   }
 };
 
-export const patchActivityById = async (id, updatedActivity) => {
+export const patchActivityById = async (id, data) => {
   try {
-    return await patchPrivateById(baseURL, id, updatedActivity);
+    return await patchPrivateById(baseURL, id, data);
   } catch (error) {
     throw new Error(error);
   }

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -19,9 +19,9 @@ export const getActivityById = async (id) => {
   }
 };
 
-export const updateActivityById = async (id) => {
+export const updateActivityById = async (id, updatedActivity) => {
   try {
-    return await patchPrivateById(baseURL, id);
+    return await patchPrivateById(baseURL, id, updatedActivity);
   } catch (error) {
     throw new Error(error);
   }

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -1,6 +1,7 @@
 import {
   deletePrivateEndPointById,
-  getPrivateById, patchPrivateById,
+  getPrivateById,
+  patchPrivateById,
   postPrivateEndPoint,
   putPrivateEndPoint,
 } from './privateApiService';

--- a/src/Services/activitiesService.js
+++ b/src/Services/activitiesService.js
@@ -1,0 +1,28 @@
+import { getPrivateById, patchPrivateById } from './privateApiService';
+import { getEndpoint } from '../Components/Services/publicApiServices';
+
+const baseURL = 'http://ongapi.alkemy.org/api/activities';
+
+export const getAllActivities = async () => {
+  try {
+    return await getEndpoint('/activities');
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const getActivityById = async (id) => {
+  try {
+    return await getPrivateById(baseURL, id);
+  } catch (error) {
+    throw new Error(error);
+  }
+};
+
+export const updateActivity = async (id) => {
+  try {
+    return await patchPrivateById(baseURL, id);
+  } catch (error) {
+    throw new Error(error);
+  }
+};

--- a/src/Services/privateApiService.js
+++ b/src/Services/privateApiService.js
@@ -13,7 +13,7 @@ const baseUrl = 'http://ongapi.alkemy.org/api/';
 const headers = {
   'Content-Type': 'application/json',
   'Access-Control-Allow-Origin': '*',
-  'access-control-allow-methods': 'GET, PUT, PATCH, POST, DELETE, OPTIONS',
+  'Access-Control-Allow-Methods': 'GET, PUT, PATCH, POST, DELETE, OPTIONS',
   ...getHeaderAuthorization(),
 };
 

--- a/src/app/activitiesReducer/activitiesActions.js
+++ b/src/app/activitiesReducer/activitiesActions.js
@@ -1,0 +1,35 @@
+import { createAsyncThunk } from '@reduxjs/toolkit';
+import {
+  getAllActivities,
+  getActivityById,
+  deleteActivityById,
+  addActivity,
+  updateActivityById,
+} from '../../Services/activitiesService';
+
+const getActivities = createAsyncThunk(
+  'activities/getActivities',
+  getAllActivities,
+);
+
+const getActivity = createAsyncThunk('activities/getActivity', getActivityById);
+
+const updateActivity = createAsyncThunk(
+  'activities/updateActivity',
+  async ({ id, data }) => {
+    const req = await updateActivityById(id, data);
+    return req;
+  },
+);
+
+const createActivity = createAsyncThunk('activities/addNewActivity', addActivity);
+
+const deleteActivity = createAsyncThunk('activities/deleteActivity', deleteActivityById);
+
+export {
+  getActivities,
+  getActivity,
+  updateActivity,
+  createActivity,
+  deleteActivity,
+};

--- a/src/app/activitiesReducer/activitiesReducer.js
+++ b/src/app/activitiesReducer/activitiesReducer.js
@@ -1,0 +1,75 @@
+import { createSlice } from '@reduxjs/toolkit';
+import {
+  createActivity,
+  deleteActivity,
+  getActivities,
+  getActivity,
+  updateActivity,
+} from './activitiesActions';
+
+const initialState = {
+  status: null,
+  activities: [],
+  activity: {},
+  error: null,
+};
+
+const isPending = (action) => action.type.endsWith('/pending');
+const isRejected = (action) => action.type.endsWith('/rejected');
+
+const activitiesSlice = createSlice({
+  name: 'activitiesReducer',
+  initialState,
+  reducer: {},
+  extraReducers: (builder) => {
+    builder
+      // getActivities Case
+      .addCase(getActivities.fulfilled, (state, action) => ({
+        ...state,
+        status: 'Success',
+        error: null,
+        activities: action.payload,
+      }))
+      // getActivity Case
+      .addCase(getActivity.fulfilled, (state, action) => ({
+        ...state, status: 'Success', error: null, activity: action.payload,
+      }))
+      // updateActivity Case
+      .addCase(updateActivity.fulfilled, (state, action) => {
+        const updatedActivities = state.activities.map((activity) => (
+          activity.id === action.payload.id
+            ? action.payload
+            : activity
+        ));
+        return {
+          ...state,
+          status: 'Success',
+          activities: updatedActivities,
+          error: null,
+        };
+      })
+      // addActivity Case
+      .addCase(createActivity.fulfilled, (state, action) => ({
+        ...state,
+        status: 'Success',
+        activities: state.activities.concat(action.payload),
+        error: null,
+      }))
+      // deleteActivity Case
+      .addCase(deleteActivity.fulfilled, (state) => ({
+        ...state,
+        status: 'Success',
+        error: null,
+      }))
+      // when a action is rejected or pending:
+      .addMatcher(isPending, (state) => ({ ...state, status: 'Loading', error: null }))
+      .addMatcher(isRejected, (state, action) => ({
+        ...state,
+        error: action?.error.message,
+        status: 'Failed',
+      }))
+      .addDefaultCase((state) => state);
+  },
+});
+
+export default activitiesSlice.reducer;

--- a/src/app/store.js
+++ b/src/app/store.js
@@ -1,9 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit';
 import userReducer from './usersReducer/userReducer';
+import activitiesReducer from './activitiesReducer/activitiesReducer';
 
 const store = configureStore({
   reducer: {
     users: userReducer,
+    activities: activitiesReducer,
   },
 });
 


### PR DESCRIPTION
# Summary
En el ticket **OT116-34**, se me pedia que extienda los servicios HTTP Base, a un servicio dedicado a los endpoints del path **/activities** de la API de alkemy.

Metodos Implementados:
- **getAllActivities**.
- **getActivity** - recibe un id numerico.
- **addActivity** - recibe un objeto.
- **updateActivityById** - recibe un id, y un objeto.
- **patchActivityById** - recibe un id, y un objeto.
- **deleteActivity** - recibe un id.

## Observacion
- El error es esperado porque pido un recurso, que previamente elimine, solamente quedaria catchear el error.

# Evidence
https://user-images.githubusercontent.com/73983475/148297539-ac5e5339-3c05-4d1f-bfa8-871e07817082.mp4