### PR TITLE
OT116-33 News services extended

### DIFF
--- a/src/Services/newsService.js
+++ b/src/Services/newsService.js
@@ -1,0 +1,53 @@
+import { getEndpoint } from '../Components/Services/publicApiServices';
+import {
+  deletePrivateEndPointById,
+  getPrivateById,
+  postPrivateEndPoint,
+  putPrivateEndPoint,
+} from './privateApiService';
+
+const URL = 'http://ongapi.alkemy.org/api/news';
+const path = 'news';
+
+export const getAllNews = async () => {
+  try {
+    return await getEndpoint(path);
+  } catch (error) {
+    throw new Error(error?.message);
+  }
+};
+
+export const getNewsById = async (id) => {
+  try {
+    return await getPrivateById(URL, id);
+  } catch (error) {
+    throw new Error(error?.message);
+  }
+};
+
+export const addNews = async (data) => {
+  try {
+    const req = await postPrivateEndPoint(path, data);
+    return req.data;
+  } catch (error) {
+    throw new Error(error?.message);
+  }
+};
+
+export const updateNews = async (id, data) => {
+  try {
+    const req = await putPrivateEndPoint(path, id, data);
+    return req.data;
+  } catch (error) {
+    throw new Error(error?.message);
+  }
+};
+
+export const deleteNews = async (id) => {
+  try {
+    const req = await deletePrivateEndPointById(path, id);
+    return req;
+  } catch (error) {
+    throw new Error(error?.message);
+  }
+};


### PR DESCRIPTION
### Ticket OT116-33: Extender servicio HTTP base para las peticiones de Novedades.

**Summary**

Se crearon los metodos necesarios para las diferentes peticiones de los componentes de Novedades a la API, utilizando el servicio HTTP base.

**Evidence**

https://user-images.githubusercontent.com/73915239/148711854-98d87db2-61ab-45c3-b740-21e6c71a0570.mp4



