### PR TITLE
OT116-85: Restringir el acceso a login a Usuarios autenticados

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "axios": "0.24.0",
     "ckeditor": "4.12.1",
     "date-fns": "2.23.0",
-    "formik": "2.2.6",
+    "formik": "^2.2.9",
     "lodash": "^4.17.21",
     "prop-types": "^15.7.2",
     "react": "17.0.2",
@@ -41,7 +41,8 @@
     "redux-thunk": "2.3.0",
     "sweetalert2": "^10.16.6",
     "swiper": "^6.8.4",
-    "web-vitals": "1.0.1"
+    "web-vitals": "1.0.1",
+    "yup": "^0.32.11"
   },
   "devDependencies": {
     "@testing-library/react": "^12.1.1",

--- a/src/Components/Home/index.jsx
+++ b/src/Components/Home/index.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Slider from '../Slider/Slider';
 import arraySlides, { arraySlidesEscolar } from '../../constants/arraySliders';
 import configSlider, { configSliderEscolar } from '../../constants/configSliders';
+import Nav from '../Nav/Nav';
 
 const Home = function () {
   return (
@@ -13,6 +14,7 @@ const Home = function () {
           margin: '0 auto',
         }}
       >
+        <Nav />
         <Slider arraySlides={arraySlides} config={configSlider} />
         <Slider arraySlides={arraySlidesEscolar} config={configSliderEscolar} />
       </section>

--- a/src/Components/Nav/Nav.jsx
+++ b/src/Components/Nav/Nav.jsx
@@ -1,0 +1,48 @@
+import * as React from 'react';
+import AppBar from '@mui/material/AppBar';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Button from '@mui/material/Button';
+import IconButton from '@mui/material/IconButton';
+import MenuIcon from '@mui/icons-material/Menu';
+import { NavLink } from 'react-router-dom';
+import { useDispatch, useSelector } from 'react-redux';
+import { logout } from '../../app/authReducer/authReducer';
+
+const Nav = () => {
+  const dispatch = useDispatch();
+  const { isAuthenticated } = useSelector((state) => state.auth);
+
+  return (
+    <Box sx={{ flexGrow: 1 }}>
+      <AppBar position="static">
+        <Toolbar>
+          <IconButton
+            size="large"
+            edge="start"
+            color="inherit"
+            aria-label="menu"
+            sx={{ mr: 2 }}
+          >
+            <MenuIcon />
+          </IconButton>
+          <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
+            Brand
+          </Typography>
+          {
+            isAuthenticated
+              ? <Button type="button" onClick={() => dispatch(logout())} style={{ color: 'white' }}>LogOut</Button>
+              : (
+                <NavLink exact to="/login" style={{ textDecoration: 'none' }}>
+                  <Button style={{ color: 'white' }}>LogIn</Button>
+                </NavLink>
+              )
+          }
+        </Toolbar>
+      </AppBar>
+    </Box>
+  );
+};
+
+export default Nav;

--- a/src/Components/PublicWeb/PublicRouter.jsx
+++ b/src/Components/PublicWeb/PublicRouter.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AnimatedSwitch } from 'react-router-transition';
 import Home from '../Home';
+import Login from '../Users/Login';
 import PublicRoute from './PublicRoute';
 
 const PublicRouter = function () {
@@ -11,6 +12,7 @@ const PublicRouter = function () {
       atActive={{ opacity: 1 }}
     >
       <PublicRoute exact path="/" component={Home} />
+      <PublicRoute exact path="/login" component={Login} />
     </AnimatedSwitch>
   );
 };

--- a/src/Components/Users/Login.jsx
+++ b/src/Components/Users/Login.jsx
@@ -1,38 +1,54 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
-import React, { useState } from 'react';
+import React, { useEffect } from 'react';
+import * as Yup from 'yup';
+import { Formik } from 'formik';
 import Button from '@mui/material/Button';
 import Box from '@mui/material/Box';
 import TextField from '@mui/material/TextField';
 import { useDispatch, useSelector } from 'react-redux';
+import { useHistory } from 'react-router-dom';
 import { login } from '../../app/authReducer/authActions';
-import { logout } from '../../app/authReducer/authReducer';
+
+const schema = Yup.object().shape({
+  email: Yup.string().email('El correo electrónico es inválido').required('Este campo es obligatorio'),
+  password: Yup.string().required('Este campo es obligatorio'),
+});
 
 const Login = () => {
   const dispatch = useDispatch();
+
   const {
-    status, error, isAuthenticated, user,
+    error, isAuthenticated,
   } = useSelector((state) => state.auth);
-  const [values, setValues] = useState({
-    email: '',
-    password: '',
-  });
 
-  const handleChange = (e) => {
-    e.preventDefault();
-    return setValues({
-      ...values,
-      [e.target.name]: e.target.value,
-    });
-  };
+  const { push } = useHistory();
 
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    dispatch(login(values));
-  };
+  useEffect(() => {
+    if (isAuthenticated) push('/');
+  }, [isAuthenticated]);
+
   return (
     <div>
-      { !isAuthenticated
-        ? (
+      <h2>Iniciar Sesión</h2>
+      <Formik
+        validationSchema={schema}
+        validateOnBlur
+        onSubmit={(data) => {
+          dispatch(login(data));
+        }}
+        initialValues={{
+          email: '',
+          password: '',
+        }}
+      >
+        {({
+          handleSubmit,
+          handleChange,
+          handleBlur,
+          values,
+          touched,
+          errors,
+        }) => (
           <Box
             component="form"
             sx={{
@@ -49,9 +65,12 @@ const Login = () => {
                 name="email"
                 value={values.email}
                 onChange={handleChange}
+                onBlur={handleBlur}
+                isInvalid={touched.email && errors.email}
                 defaultValue="ejemplo@ejemplo.com"
                 helperText="Ingresa tu correo electrónico"
               />
+              <div type="invalid">{errors.email}</div>
               <TextField
                 id="outlined-password-input"
                 label="*******"
@@ -59,25 +78,17 @@ const Login = () => {
                 name="password"
                 value={values.password}
                 onChange={handleChange}
+                onBlur={handleBlur}
+                isInvalid={touched.password && errors.password}
                 autoComplete="current-password"
                 helperText="Ingresa tu contraseña"
               />
+              <div type="invalid">{errors.password}</div>
             </div>
             <Button type="submit" variant="contained" onClick={handleSubmit}>LogIn</Button>
           </Box>
-        )
-        : (
-          <div>
-            <h3>Usuario Logueado</h3>
-            <p>
-              Estado:
-              {' '}
-              {status}
-            </p>
-            <p>{user.name}</p>
-            <Button type="button" variant="contained" onClick={() => dispatch(logout())}>LogOut</Button>
-          </div>
         )}
+      </Formik>
       {
         error && <p>{error}</p>
       }

--- a/src/Components/Users/Login.jsx
+++ b/src/Components/Users/Login.jsx
@@ -1,0 +1,90 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import React, { useState } from 'react';
+import Button from '@mui/material/Button';
+import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import { useDispatch, useSelector } from 'react-redux';
+import { login } from '../../app/authReducer/authActions';
+import { logout } from '../../app/authReducer/authReducer';
+
+const Login = () => {
+  const dispatch = useDispatch();
+  const {
+    status, error, isAuthenticated, user,
+  } = useSelector((state) => state.auth);
+  const [values, setValues] = useState({
+    email: '',
+    password: '',
+  });
+
+  const handleChange = (e) => {
+    e.preventDefault();
+    return setValues({
+      ...values,
+      [e.target.name]: e.target.value,
+    });
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    dispatch(login(values));
+  };
+  return (
+    <div>
+      { !isAuthenticated
+        ? (
+          <Box
+            component="form"
+            sx={{
+              '& .MuiTextField-root': { m: 1, width: '25ch' },
+            }}
+            noValidate
+            autoComplete="off"
+          >
+            <div>
+              <TextField
+                required
+                id="outlined-required"
+                label="Email"
+                name="email"
+                value={values.email}
+                onChange={handleChange}
+                defaultValue="ejemplo@ejemplo.com"
+                helperText="Ingresa tu correo electrónico"
+              />
+              <TextField
+                id="outlined-password-input"
+                label="*******"
+                type="password"
+                name="password"
+                value={values.password}
+                onChange={handleChange}
+                autoComplete="current-password"
+                helperText="Ingresa tu contraseña"
+              />
+            </div>
+            <Button type="submit" variant="contained" onClick={handleSubmit}>LogIn</Button>
+          </Box>
+        )
+        : (
+          <div>
+            <h3>Usuario Logueado</h3>
+            <p>
+              Estado:
+              {' '}
+              {status}
+            </p>
+            <p>{user.name}</p>
+            <Button type="button" variant="contained" onClick={() => dispatch(logout())}>LogOut</Button>
+          </div>
+        )}
+      {
+        error && <p>{error}</p>
+      }
+
+    </div>
+
+  );
+};
+
+export default Login;

--- a/src/app/authReducer/authReducer.js
+++ b/src/app/authReducer/authReducer.js
@@ -44,10 +44,10 @@ const authSlice = createSlice({
         status: 'Loading',
         error: null,
       }))
-      .addMatcher(isRejected, (state, action) => (({
+      .addMatcher(isRejected, (state) => (({
         ...state,
         status: 'Failed',
-        error: action?.error.message,
+        error: 'Los datos ingresados son incorrectos',
       })))
       .addDefaultCase((state) => state);
   },


### PR DESCRIPTION
# OT116-85: Restringir el acceso a login a Usuarios autenticados

## Resumen:
- Se crea formulario de login con validaciones realizadas con Formik y Yup.
- Se modifica el authReducer para que muestre un error entendible al usuario al ingresar datos incorrectos.
- Utilización de material UI.
- Creación de un componente Nav que contiene un botón con el enlace a la pantalla de logIn, o un botón de LogOut segun el estado de autorización del usuario en la aplicación.
- Cuando el usuario está autenticado, no podrá ingresar a la ruta /login, y es redirigido al Home. 
- El botón de LogIn no se muestra cuando el usuario esté autenticado, y cambia su función para poder realizar el LogOut.

## Criterios de aceptación:
Cuando el usuario está autenticado, no deberá poder ingresar a la ruta /login, y deberá ser redirigido al Home. Además, asegurar que el botón de Log In tampoco sea mostrado cuando el usuario esté autenticado.

## Evidencia

https://user-images.githubusercontent.com/80296219/149435645-057ea0c8-31d2-4ed0-9e57-769e4dd03b82.mp4


